### PR TITLE
Update SConstruct for changes to ALTA

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -23,7 +23,7 @@ env.AppendUnique(CPPDEFINES = 'SINGLE_PRECISION')
 env.AppendUnique(CPPDEFINES = 'SPECTRUM_SAMPLES=3')
 
 if sys.platform == 'posix' or sys.platform == 'linux2':
-	env.AppendUnique(CCFLAGS = ['-g'])
+	env.AppendUnique(CCFLAGS = ['-g','-std=c++11'])
 	env.AppendUnique(CPPPATH = [os.path.join(mitsubaPath, 'include')])
 	env.AppendUnique(CPPPATH = [os.path.join(altaPath, 'sources'), os.path.join(altaPath, 'external/build/include')])
 
@@ -32,7 +32,8 @@ if sys.platform == 'posix' or sys.platform == 'linux2':
 
 	libpath = os.path.join(mitsubaPath, 'dist')
 	env.AppendUnique(LIBPATH = [libpath])
-	env.AppendUnique(LIBPATH = [os.path.join(altaPath, 'sources/build')])
+	env.AppendUnique(LIBPATH = [os.path.join(altaPath, 'build/plugins')])
+	env.AppendUnique(LIBPATH = [os.path.join(altaPath, 'build/core')])
 	libs = [f for f in os.listdir(libpath) if f.endswith('.so')]
 	env.AppendUnique(LIBS = [libs, 'core'])
 	env.AppendUnique(RPATH = libpath)


### PR DESCRIPTION
It seems that at least since v0.2 of ALTA, the directory structure has changed, and the build file of this plugin needed to be changed to account for that.

Also, it might be worthwhile to add an error message when a user hasn't supplied a binary file, rather then crashing with a segfault, or at least make a mention of this in the README. When I first tried to use this, I was helping a friend to compile it, so I wasn't fully aware of what it does. I assumed that it searches for pre-packaged files in the companion alta directory, but it doesn't. The segfault confused me for a bit of time and I at first thought that we wouldn't be able to do anything worthwhile.

Best,
Rob